### PR TITLE
[어헛차/#37/UI/Logic] - 설정 화면 UI 및 로직 구현 완료

### DIFF
--- a/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
@@ -94,7 +94,7 @@ class MainActivity : AppCompatActivity() {
                 //마이페이지 화면
                 R.id.mypageFragment -> {
                     supportFragmentManager.beginTransaction()
-                        .replace(R.id.main_fragmentContainer, SettingFragment())
+                        .replace(R.id.main_fragmentContainer, MypageFragment())
                         .commit()
                     binding.mainBnv.visibility = ConstraintLayout.VISIBLE
                     true

--- a/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
@@ -17,6 +17,7 @@ import com.example.hwaroak.ui.diary.DiaryFragment
 import com.example.hwaroak.ui.friend.FriendFragment
 import com.example.hwaroak.ui.locker.LockerFragment
 import com.example.hwaroak.ui.mypage.MypageFragment
+import com.example.hwaroak.ui.mypage.SettingFragment
 import com.example.hwaroak.ui.notification.NoticeFragment
 import com.kakao.sdk.common.util.Utility
 
@@ -93,7 +94,7 @@ class MainActivity : AppCompatActivity() {
                 //마이페이지 화면
                 R.id.mypageFragment -> {
                     supportFragmentManager.beginTransaction()
-                        .replace(R.id.main_fragmentContainer, MypageFragment())
+                        .replace(R.id.main_fragmentContainer, SettingFragment())
                         .commit()
                     binding.mainBnv.visibility = ConstraintLayout.VISIBLE
                     true

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/SettingFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/SettingFragment.kt
@@ -1,0 +1,184 @@
+package com.example.hwaroak.ui.mypage
+
+import android.app.TimePickerDialog
+import android.content.SharedPreferences
+import android.content.res.ColorStateList
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.content.edit
+import com.example.hwaroak.R
+import com.example.hwaroak.databinding.FragmentSettingBinding
+import java.util.Calendar
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [SettingFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class SettingFragment : Fragment() {
+    // TODO: Rename and change types of parameters
+    private var param1: String? = null
+    private var param2: String? = null
+
+    //세팅 정보를 저장할 sharedPrefernce
+    private lateinit var settingPref : SharedPreferences
+    private var isRemind : Boolean = true
+    private var isFireAlarm : Boolean = true
+    private var isOffAlarm : Boolean = false
+    private var hour : Int = 0
+    private var minute : Int = 0
+
+
+    private lateinit var binding: FragmentSettingBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            param1 = it.getString(ARG_PARAM1)
+            param2 = it.getString(ARG_PARAM2)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        binding = FragmentSettingBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        //sharedPreference 초기화
+        /**
+         * sharedPreference : setting 사용
+         * 내부 인자
+         * isRemind : 리마인더 받기 여부 (Boolean)
+         * isFireAlarm : 불 키우기 알람 받기 여부 (Boolean)
+         * isOffAlarm : 모든 알람 끄기 여부 (Boolean)
+         * hour : 리마인더 시간 (Int)
+         * minute : 리마인더 분 (Int)
+         * **/
+        settingPref = requireActivity().getSharedPreferences("setting", 0)
+        isRemind = settingPref.getBoolean("isRemind", true)
+        isFireAlarm = settingPref.getBoolean("isFireAlarm", true)
+        isOffAlarm = settingPref.getBoolean("isOffAlarm", false)
+        hour = settingPref.getInt("hour", 0)
+        minute = settingPref.getInt("minute", 0)
+
+        //초기 설정
+        binding.settingGetReminderSwitch.isChecked = isRemind
+        binding.settingFireAlarmSwitch.isChecked = isFireAlarm
+        binding.settingOffAlarmSwitch.isChecked = isOffAlarm
+        binding.settingTimeTv.text = String.format("%02d:%02d", hour, minute)
+
+        //UI 세팅
+        updateUISetting()
+        //버튼 setting
+        settingListener()
+
+    }
+    
+    
+    //각 스위치를 눌렀을 때 로직 구성 함수
+    private fun updateUISetting(){
+        val disableAll = binding.settingOffAlarmSwitch.isChecked
+        val remind = binding.settingGetReminderSwitch.isChecked
+        val fire = binding.settingFireAlarmSwitch.isChecked
+
+        settingPref.edit { putBoolean("isRemind", remind).
+                            putBoolean("isFireAlarm", fire).
+                            putBoolean("isOffAlarm", disableAll).apply() }
+
+        //스위치는 버튼 활성화 된 상태에만 OK
+        var color = ContextCompat.getColor(requireContext(), R.color.colorGrayIcon)
+        if(binding.settingGetReminderSwitch.isChecked && !disableAll){
+            binding.settingReminderTimeBtn.isEnabled = true
+            color = ContextCompat.getColor(requireContext(), R.color.colorPrimary)
+        }
+        else{
+            binding.settingReminderTimeBtn.isEnabled = false
+            color = ContextCompat.getColor(requireContext(), R.color.colorGrayIcon)
+        }
+        binding.settingReminderTimeBtn.backgroundTintList = ColorStateList.valueOf(color)
+
+    }
+
+    //각 버튼 리스너 등록
+    private fun settingListener(){
+        //리마인더 받기
+        binding.settingGetReminderSwitch.setOnCheckedChangeListener { _, isChecked ->
+            settingPref.edit { putBoolean("isRemind", isChecked).apply() }
+
+            updateUISetting()
+        }
+        //불 키우기
+        binding.settingFireAlarmSwitch.setOnCheckedChangeListener { _, isChecked ->
+            if(isChecked){binding.settingOffAlarmSwitch.isChecked = false}
+            updateUISetting()
+        }
+        //모두 끄기
+        binding.settingOffAlarmSwitch.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                // 켜지면 다른 스위치 꺼버리기
+                binding.settingGetReminderSwitch.isChecked = false
+                binding.settingFireAlarmSwitch.isChecked  = false
+            }
+            updateUISetting()
+
+        }
+        //시간 설정 버튼
+        binding.settingReminderTimeBtn.setOnClickListener {
+            val cal = Calendar.getInstance()
+            val tp = TimePickerDialog(
+                requireContext(),
+                { _, h, m ->
+                    //선택한 시간 포맷 & 저장
+                    binding.settingTimeTv.text = String.format("%02d:%02d", h, m)
+                    settingPref.edit {
+                        putInt("hour", h)
+                        .putInt("minute", m)
+                        .apply()
+                    }
+                },
+                cal.get(Calendar.HOUR_OF_DAY),
+                cal.get(Calendar.MINUTE),
+                true //24h 형식(00-23시)
+            )
+            tp.show()
+        }
+    }
+
+    companion object {
+        /**
+         * Use this factory method to create a new instance of
+         * this fragment using the provided parameters.
+         *
+         * @param param1 Parameter 1.
+         * @param param2 Parameter 2.
+         * @return A new instance of fragment SettingFragment.
+         */
+        // TODO: Rename and change types and number of parameters
+        @JvmStatic
+        fun newInstance(param1: String, param2: String) =
+            SettingFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_PARAM1, param1)
+                    putString(ARG_PARAM2, param2)
+                }
+            }
+    }
+}

--- a/app/src/main/res/color/color_switch_toggle.xml
+++ b/app/src/main/res/color/color_switch_toggle.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Checked 상태일 때 Track 색 -->
+    <item android:color="@color/colorPrimary" android:state_checked="true"/>
+    <!-- Unchecked 상태일 때 Track 색 -->
+    <item android:color="@color/colorGrayIcon" android:state_checked="false"/>
+</selector>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@color/colorBackground"
+    tools:context=".ui.mypage.SettingFragment">
+
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/setting_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.2"/>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/setting_one_cdv"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="15dp"
+        android:background="@color/colorFrameBackground"
+        android:backgroundTint="@color/colorFrameBackground"
+        app:cardCornerRadius="10dp"
+        app:cardElevation="1dp"
+        app:strokeWidth="0dp"
+        app:layout_constraintTop_toTopOf="@id/setting_guideline"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="15dp"
+            >
+
+            <TextView
+                android:id="@+id/setting_getReminder_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/freesentation4_16sp"
+                android:text="리마인더 받기"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/setting_reminderTime_tv"
+                />
+            
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/setting_getReminder_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:trackTint="@color/color_switch_toggle"
+                app:thumbTint="@color/white"
+                app:layout_constraintTop_toTopOf="@id/setting_getReminder_tv"
+                app:layout_constraintBottom_toBottomOf="@id/setting_getReminder_tv"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <TextView
+                android:id="@+id/setting_reminderTime_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/freesentation4_16sp"
+                android:text="리마인더 받는 시간"
+                android:layout_marginTop="25dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/setting_getReminder_tv"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/setting_reminderTime_btn"
+                android:layout_width="0dp"
+                android:layout_height="30dp"
+                android:backgroundTint="@color/colorPrimary"
+                app:iconGravity="textStart"
+                app:iconTint="@null"
+                android:elevation="0dp"
+                android:insetLeft="0dp"
+                android:insetTop="0dp"
+                android:insetRight="0dp"
+                android:insetBottom="0dp"
+                android:paddingVertical="8dp"
+                app:cornerRadius="20dp"
+                style="@style/Widget.MaterialComponents.Button"
+                app:layout_constraintStart_toStartOf="@id/setting_getReminder_switch"
+                app:layout_constraintEnd_toEndOf="@id/setting_getReminder_switch"
+                app:layout_constraintTop_toTopOf="@id/setting_reminderTime_tv"
+                app:layout_constraintBottom_toBottomOf="@id/setting_reminderTime_tv"/>
+
+            <TextView
+                android:id="@+id/setting_time_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="12:12"
+                android:gravity="center"
+                android:elevation="2dp"
+                style="@style/freesentation5_16sp"
+                android:textSize="14sp"
+                android:textColor="@color/white"
+                app:layout_constraintStart_toStartOf="@id/setting_reminderTime_btn"
+                app:layout_constraintEnd_toEndOf="@id/setting_reminderTime_btn"
+                app:layout_constraintTop_toTopOf="@id/setting_reminderTime_btn"
+                app:layout_constraintBottom_toBottomOf="@id/setting_reminderTime_btn"/>
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/setting_two_cdv"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="15dp"
+        android:background="@color/colorFrameBackground"
+        android:backgroundTint="@color/colorFrameBackground"
+        android:layout_marginTop="20dp"
+        app:cardCornerRadius="10dp"
+        app:cardElevation="1dp"
+        app:strokeWidth="0dp"
+        app:layout_constraintTop_toBottomOf="@id/setting_one_cdv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="10dp"
+            >
+
+            <TextView
+                android:id="@+id/setting_fireAlarm_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/freesentation4_16sp"
+                android:text="불 키우기 알림 받기"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/setting_fireAlarm_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:trackTint="@color/color_switch_toggle"
+                app:thumbTint="@color/white"
+                app:layout_constraintTop_toTopOf="@id/setting_fireAlarm_tv"
+                app:layout_constraintBottom_toBottomOf="@id/setting_fireAlarm_tv"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/setting_three_cdv"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="15dp"
+        android:background="@color/colorFrameBackground"
+        android:backgroundTint="@color/colorFrameBackground"
+        android:layout_marginTop="20dp"
+        app:cardCornerRadius="10dp"
+        app:cardElevation="1dp"
+        app:strokeWidth="0dp"
+        app:layout_constraintTop_toBottomOf="@id/setting_two_cdv"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="20dp"
+            android:paddingVertical="10dp"
+            >
+
+            <TextView
+                android:id="@+id/setting_offAlarm_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/freesentation4_16sp"
+                android:text="모든 알림 끄기"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/setting_offAlarm_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:trackTint="@color/color_switch_toggle"
+                app:thumbTint="@color/white"
+                app:layout_constraintTop_toTopOf="@id/setting_offAlarm_tv"
+                app:layout_constraintBottom_toBottomOf="@id/setting_offAlarm_tv"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,9 +4,9 @@
     <string name="hello_blank_fragment">Hello blank fragment</string>
 
 
-        <!-- ... 기존 리소스들 ... -->
+    <!-- ... 기존 리소스들 ... -->
 
-        <string name="terms_full"><![CDATA[
+    <string name="terms_full"><![CDATA[
 최종 업데이트: 2025년 6월 25일\n
 본 약관은 감정 기록 기반 정서 일기 서비스 “화록”(이하 “서비스”)의 이용과 관련하여, 화록을 운영하는 개발팀(이하 “운영자”)과 이용자의 권리, 의무 및 책임사항을 규정합니다.\n\n
 


### PR DESCRIPTION
## SettingFragment 알림 세팅 기능 구현

- **SettingFragment**를 생성하여 알림 세팅 기능을 구현했습니다.
- 공용으로 사용할 **SharedPreferences**를 정의하고, 이를 정리한 Notion 페이지를 신설했습니다.  
   [SharedPreference Notion 페이지](https://www.notion.so/SharedPreference-233ff3beec76806789fbc09236ae4fdc)

---

### SharedPreferences 정보

- **파일 이름**: `setting`
- **Key 목록**:

| Key           | Type    | Default | 설명                              |
| ------------- | ------- | ------- | --------------------------------- |
| `isRemind`    | Boolean | `true`  | 리마인더 받기 토글 여부           |
| `isFireAlarm` | Boolean | `true`  | “불 키우기” 알림 받기 토글 여부   |
| `isOffAlarm`  | Boolean | `false` | 모든 알림 끄기 토글 여부          |
| `hour`        | Int     | `0`     | 리마인더 시 (0–23)                |
| `minute`      | Int     | `0`     | 리마인더 분 (0–59)                |
