### PR TITLE
[리암/Logic] - 아이템 api 연결 중간반영

### DIFF
--- a/app/src/main/java/com/example/hwaroak/adaptor/HomeItemRVAdaptor.kt
+++ b/app/src/main/java/com/example/hwaroak/adaptor/HomeItemRVAdaptor.kt
@@ -9,7 +9,7 @@ import com.example.hwaroak.R
 import com.example.hwaroak.data.LockerItem
 
 class HomeItemRVAdapter : RecyclerView.Adapter<HomeItemRVAdapter.ViewHolder>() {
-    private var items = listOf<LockerItem>()
+    private var items = listOf<LockerItem?>()
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val imageView: ImageView = view.findViewById(R.id.iv_item_image)
@@ -22,12 +22,12 @@ class HomeItemRVAdapter : RecyclerView.Adapter<HomeItemRVAdapter.ViewHolder>() {
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.imageView.setImageResource(items[position].imageRes)
+        items[position]?.let { holder.imageView.setImageResource(it.imageRes) }
     }
 
     override fun getItemCount(): Int = items.size
 
-    fun setData(newItems: List<LockerItem>) {
+    fun setData(newItems: List<LockerItem?>) {
         items = newItems
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/hwaroak/adaptor/LockerItemRVAdaptor.kt
+++ b/app/src/main/java/com/example/hwaroak/adaptor/LockerItemRVAdaptor.kt
@@ -10,7 +10,7 @@ import com.example.hwaroak.data.LockerItem
 
 // 아이템이 없을 수도 있으므로 List<Item?> 타입으로 받기
 class LockerItemRVAdaptor(
-    private val itemList: List<LockerItem?>,
+    private var itemList: List<LockerItem?>,
     private val onShowConfirmDialog: (LockerItem?) -> Unit
 ) : RecyclerView.Adapter<LockerItemRVAdaptor.ViewHolder>() {
 
@@ -49,5 +49,10 @@ class LockerItemRVAdaptor(
     // 전체 아이템 개수를 반환
     override fun getItemCount(): Int {
         return itemList.size
+    }
+
+    fun updateData(newList: List<LockerItem?>) {
+        itemList = newList
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/example/hwaroak/api/HwaRoakClient.kt
+++ b/app/src/main/java/com/example/hwaroak/api/HwaRoakClient.kt
@@ -1,8 +1,9 @@
 package com.example.hwaroak.api
 
 import com.example.hwaroak.api.diary.network.DiaryService
-import com.example.hwaroak.api.home.network.ItemService
+import com.example.hwaroak.api.home.network.ItemApiService
 import com.example.hwaroak.api.login.network.LoginService
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -19,9 +20,31 @@ object HwaRoakClient {
         level = HttpLoggingInterceptor.Level.BODY
     }
 
+    // Liam
+    // TODO: 실제로 앱에서 토큰을 저장하고 가져오는 로직으로 대체해야 합니다.
+    // 여기서는 임시로 토큰을 저장할 변수를 선언합니다.
+    // 실제 앱에서는 SharedPreferences나 다른 보안 저장소에 저장해야 합니다.
+    @Volatile // 여러 스레드에서 접근할 수 있으므로 volatile 키워드 추가
+    var currentAccessToken: String? = null // 로그인 성공 후 여기에 토큰 저장
+
+    // 인증 헤더를 추가하는 인터셉터
+    private val authInterceptor = Interceptor { chain ->
+        val originalRequest = chain.request()
+        val builder = originalRequest.newBuilder()
+
+        // currentAccessToken이 null이 아니면 Authorization 헤더 추가
+        currentAccessToken?.let { token ->
+            builder.header("Authorization", "Bearer $token")
+        }
+
+        val request = builder.build()
+        chain.proceed(request)
+    }
+
     //클라이언트(각 연결/쓰기/읽기 작업에서 최대 60초 대기)
     private val client = OkHttpClient.Builder()
         .addInterceptor(logging)
+        .addInterceptor(authInterceptor) // **인증 인터셉터 추가**
         .connectTimeout(60, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .writeTimeout(60, TimeUnit.SECONDS)
@@ -40,7 +63,9 @@ object HwaRoakClient {
     //일기 관련
     val diaryService: DiaryService = retrofit.create(DiaryService::class.java)
     //아이템 관련
-    val itemService: ItemService = retrofit.create(ItemService::class.java)
+    val itemApiService: ItemApiService by lazy { // ItemApiService를 사용하도록 변경
+        retrofit.create(ItemApiService::class.java)
+    }
 
 
 

--- a/app/src/main/java/com/example/hwaroak/api/home/network/ItemApiService.kt
+++ b/app/src/main/java/com/example/hwaroak/api/home/network/ItemApiService.kt
@@ -4,22 +4,28 @@ import com.example.hwaroak.api.home.model.ApiResponse
 import com.example.hwaroak.api.home.model.ItemDto
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.PATCH
 import retrofit2.http.Path
 
-interface ItemService {
+interface ItemApiService {
 
     // 1. 보유 아이템 리스트 조회
     @GET("api/v1/members/items")
-    suspend fun getItemList(): Response<ApiResponse<List<ItemDto>>>
+    suspend fun getItemList(
+        @Header("Authorization") token: String
+    ): Response<ApiResponse<List<ItemDto>>>
 
     // 2. 대표 아이템 조회
     @GET("api/v1/members/items/selected")
-    suspend fun getEquippedItem(): Response<ApiResponse<ItemDto>>
+    suspend fun getEquippedItem(
+        @Header("Authorization") token: String
+    ): Response<ApiResponse<ItemDto>>
 
     // 3. 대표 아이템 변경
     @PATCH("api/v1/members/items/{itemId}/selected")
-    suspend fun selectItem(
+    suspend fun changeEquippedItem(
+        @Header("Authorization") token: String,
         @Path("itemId") itemId: Int
     ): Response<ApiResponse<ItemDto>>
 }

--- a/app/src/main/java/com/example/hwaroak/api/home/repository/ItemRepository.kt
+++ b/app/src/main/java/com/example/hwaroak/api/home/repository/ItemRepository.kt
@@ -1,23 +1,33 @@
+// ItemRepository.kt
 package com.example.hwaroak.api.home.repository
 
 import com.example.hwaroak.api.home.model.ApiResponse
 import com.example.hwaroak.api.home.model.ItemDto
-import com.example.hwaroak.api.home.network.ItemService
+import com.example.hwaroak.api.home.network.ItemApiService // ItemApiService 임포트 확인
 
-class ItemRepository(private val service: ItemService) {
+class ItemRepository(private val service: ItemApiService) {
 
-    suspend fun getItems(): List<ItemDto>? {
-        val response = service.getItemList()
+    // `token` 파라미터 추가
+    suspend fun getItems(accessToken: String): List<ItemDto>? {
+        // "Bearer " 접두사 추가 (서버 요구사항에 따라 다름)
+        val token = if (accessToken.startsWith("Bearer ")) accessToken else "Bearer $accessToken"
+        val response = service.getItemList(token) // token 전달
         return response.body()?.data
     }
 
-    suspend fun getEquippedItem(): ItemDto? {
-        val response = service.getEquippedItem()
+    // `token` 파라미터 추가
+    suspend fun getEquippedItem(accessToken: String): ItemDto? {
+        // "Bearer " 접두사 추가 (서버 요구사항에 따라 다름)
+        val token = if (accessToken.startsWith("Bearer ")) accessToken else "Bearer $accessToken"
+        val response = service.getEquippedItem(token) // token 전달
         return response.body()?.data
     }
 
-    suspend fun changeEquippedItem(itemId: Int): ApiResponse<ItemDto>? {
-        val response = service.selectItem(itemId)
+    // `token` 파라미터 추가 및 `service` 사용으로 통일
+    suspend fun changeEquippedItem(accessToken: String, itemId: Int): ApiResponse<ItemDto>? {
+        // "Bearer " 접두사 추가 (서버 요구사항에 따라 다름)
+        val token = if (accessToken.startsWith("Bearer ")) accessToken else "Bearer $accessToken"
+        val response = service.changeEquippedItem(token, itemId) // token 전달
         return response.body()
     }
 }

--- a/app/src/main/java/com/example/hwaroak/api/login/repository/LoginRepository.kt
+++ b/app/src/main/java/com/example/hwaroak/api/login/repository/LoginRepository.kt
@@ -3,6 +3,7 @@ package com.example.hwaroak.api.login.repository
 import android.content.SharedPreferences
 import android.util.Log
 import androidx.core.content.edit
+import com.example.hwaroak.api.HwaRoakClient
 import com.example.hwaroak.api.login.model.LoginRequest
 import com.example.hwaroak.api.login.model.TokenGetRequest
 import com.example.hwaroak.api.login.network.LoginService
@@ -20,6 +21,9 @@ class LoginRepository(private val service: LoginService,
             if(response.isSuccessful){
                 //인자로 받은 sharedPref를 IN
                 response.body()!!.data!!.let { memberData ->
+                    //liam
+                    HwaRoakClient.currentAccessToken = memberData.accessToken
+                    //
                     pref.edit{
                         putInt("memberId", memberData.memberId)
                         putString("nickname", memberData.nickname)

--- a/app/src/main/java/com/example/hwaroak/data/ItemViewModel.kt
+++ b/app/src/main/java/com/example/hwaroak/data/ItemViewModel.kt
@@ -1,33 +1,111 @@
 package com.example.hwaroak.data
 
+import android.util.Log
+import android.widget.ImageView
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.hwaroak.R
-import com.example.hwaroak.data.LockerItem
+import com.example.hwaroak.api.HwaRoakClient
+import com.example.hwaroak.api.home.repository.ItemRepository // ItemRepository 임포트 추가
+import com.example.hwaroak.api.home.model.ItemDto // ItemDto 임포트 추가
+import kotlinx.coroutines.launch
 
-class ItemViewModel : ViewModel() {
-    private val _homeItemList = MutableLiveData<List<LockerItem>>()
-    val homeItemList: LiveData<List<LockerItem>> = _homeItemList
+// ItemRepository를 생성자로 주입받도록 변경합니다.
+// 이 ViewModel을 사용하는 곳(예: HomeFragment, LockerFragment)에서 ItemRepository 인스턴스를 넘겨줘야 합니다.
+class ItemViewModel(private val itemRepository: ItemRepository) : ViewModel() {
+    private val _homeItemList = MutableLiveData<List<LockerItem?>>()
+    val homeItemList: LiveData<List<LockerItem?>> = _homeItemList
 
     init {
-        val initalItem = LockerItem(
-            id = 0,
-            name = "default",
-            imageRes = R.drawable.img_item_lock
-        )
-        _homeItemList.value = listOf(initalItem)
+        viewModelScope.launch {
+            // HwaRoakClient.currentAccessToken이 null이 아닐 때만 API 호출
+            HwaRoakClient.currentAccessToken?.let { token ->
+                val equippedItemDto = itemRepository.getEquippedItem(token) // 토큰 전달
+                equippedItemDto?.let {
+                    val initialItem = LockerItem(
+                        id = it.itemId,
+                        name = it.name,
+                        imageRes = getImageResForName(it.name)
+                    )
+                    _homeItemList.value = listOf(initialItem)
+                }
+            } ?: run {
+                // 토큰이 없는 경우 (예: 로그인 안 된 상태), 적절한 처리 (오류 메시지, 기본 아이템 등)
+                // Log.e("ItemViewModel", "Access token is null, cannot fetch equipped item.")
+                _homeItemList.value = emptyList() // 또는 기본 아이템 설정
+            }
+        }
     }
 
+    // 홈 화면에 표시될 아이템을 변경할 때 호출되는 함수입니다.
     fun setHomeItem(item: LockerItem) {
-        _homeItemList.value = listOf(item)
+        viewModelScope.launch {
+            HwaRoakClient.currentAccessToken?.let { token ->
+                val response = itemRepository.changeEquippedItem(token, item.id) // 토큰 전달
+                if (response?.status == "OK") {
+                    // 성공 처리 (예: _homeItemList 업데이트)
+                    _homeItemList.value = listOf(item)
+                } else {
+                    // 실패 처리 (예: 오류 메시지 토스트)
+                    Log.e("ItemViewModel", "Failed to change item: ${response?.message}")
+                }
+            } ?: run {
+                Log.e("ItemViewModel", "Access token is null, cannot change home item.")
+            }
+        }
     }
-    // 홈 보상 받기
-    private val _rewardItemList = MutableLiveData<List<LockerItem>>()
-    val rewardItemList: LiveData<List<LockerItem>> = _rewardItemList
 
-    fun setRewardItems(items: List<LockerItem>) {
+    // 보상으로 받은 아이템 목록을 설정하는 부분 (이 부분은 API 연결과 직접적인 관련이 적고 기존과 동일)
+    private val _rewardItemList = MutableLiveData<List<LockerItem?>>()
+    val rewardItemList: LiveData<List<LockerItem?>> = _rewardItemList
+
+    fun setRewardItems(items: List<LockerItem?>) {
         _rewardItemList.value = items
     }
-}
 
+    // 모든 보유 아이템을 불러오는 함수 (예시)
+    fun loadUserItems() {
+        viewModelScope.launch {
+            HwaRoakClient.currentAccessToken?.let { token ->
+                val items = itemRepository.getItems(token) // 토큰 전달
+                val lockerItems = items?.map {
+                    LockerItem(it.itemId, it.name, getImageResForName(it.name))
+                } ?: emptyList()
+                _rewardItemList.value = lockerItems
+            } ?: run {
+                // Log.e("ItemViewModel", "Access token is null, cannot fetch reward items.")
+                _rewardItemList.value = emptyList()
+            }
+        }
+    }
+
+
+    // ItemDto의 name(문자열)에 따라 안드로이드 drawable 리소스 ID(정수)를 반환하는 헬퍼 함수입니다.
+    // 이 함수에 모든 아이템 이름과 해당 이미지 리소스 매핑을 추가해야 합니다.
+    // ItemViewModel.kt
+    private fun getImageResForName(itemName: String): Int {
+        return when (itemName) {
+            "자물쇠" -> R.drawable.img_item_lock // 이 부분은 유지
+            "cheeze" -> R.drawable.img_item_cheeze // R.id 대신 R.drawable
+            "chicken" -> R.drawable.img_item_chicken // R.id 대신 R.drawable
+            "chopstick" -> R.drawable.img_item_chopstick // R.id 대신 R.drawable
+            "coal" -> R.drawable.img_item_coal // R.id 대신 R.drawable
+            "cup" -> R.drawable.img_item_cup // R.id 대신 R.drawable
+            "egg" -> R.drawable.img_item_egg // R.id 대신 R.drawable
+            "mashmellow" -> R.drawable.img_item_mashmellow // R.id 대신 R.drawable
+            "meat" -> R.drawable.img_item_meat // R.id 대신 R.drawable
+            "paper" -> R.drawable.img_item_paper // R.id 대신 R.drawable
+            "potato" -> R.drawable.img_item_potato // R.id 대신 R.drawable
+            "ruby" -> R.drawable.img_item_ruby // R.id 대신 R.drawable (만약 이 리소스가 있다면)
+            "soup" -> R.drawable.img_item_soup // R.id 대신 R.drawable
+            "tire" -> R.drawable.img_item_tire // R.id 대신 R.drawable
+            "tissue" -> R.drawable.img_item_tissue // **여기! R.id 대신 R.drawable.img_item_tissue 로 변경**
+            "trash" -> R.drawable.img_item_trash // R.id 대신 R.drawable
+            else -> R.drawable.img_item_lock // 기본값은 자물쇠 이미지로 유지
+        }
+    }
+
+// ... (나머지 코드)
+}

--- a/app/src/main/java/com/example/hwaroak/data/ItemViewModelFactory.kt
+++ b/app/src/main/java/com/example/hwaroak/data/ItemViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.example.hwaroak.data
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.hwaroak.api.home.repository.ItemRepository
+
+class ItemViewModelFactory(private val itemRepository: ItemRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ItemViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ItemViewModel(itemRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
loginrepository 파일과 hwaroakclient 파일 수정하였음.
또한 추가된 코드엔 주석으로 닉네임 표시해 놓았음.

- 현재 아이템 api 작동흐름

1. 카카오 로그인 성공 후, 서버로부터 accessToken을 포함한 사용자 데이터를 받은 후
2. accessToken을 HwaRoakClient.currentAccessToken 변수에 저장
3. 이후 api/v1/members/items/selected와 같은 다른 API를 호출할 때, HwaRoakClient의 authInterceptor가 currentAccessToken에 저장된 토큰을 자동으로 Authorization 헤더에 추가하여 서버에 요청 후 응답받음.

- 아이템api 연결 성공 로그
2025-07-28 08:25:36.865 7575-7619 okhttp.OkHttpClient com.example.hwaroak I {"status":"OK","code":"200OK","message":"요청에 성공하였습니다.","data":{"item_id":1,"name":"tissue","level":1,"isSelected":true}}