### PR TITLE
[어헛차/#72] - 상단바 로직 연결 및 SSE를 이용한 푸시 알림 구현

### DIFF
--- a/.kotlin/errors/errors-1754050349984.log
+++ b/.kotlin/errors/errors-1754050349984.log
@@ -1,0 +1,51 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #2 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+Problems may have occurred during auto-selection of GC. The preferred GC is Parallel GC.
+If the problems persist, try adding the JVM option to the Kotlin daemon JVM arguments: -XX:-UseParallelGC.
+GC auto-selection logic is disabled temporary for the next daemon startup.
+
+error message: Failed connecting to the daemon in 4 retries
+
+error message: Daemon compilation failed: Could not connect to Kotlin compile daemon
+java.lang.RuntimeException: Could not connect to Kotlin compile daemon
+	at org.jetbrains.kotlin.compilerRunner.GradleKotlinCompilerWork.compileWithDaemon(GradleKotlinCompilerWork.kt:214)
+	at org.jetbrains.kotlin.compilerRunner.GradleKotlinCompilerWork.compileWithDaemonOrFallbackImpl(GradleKotlinCompilerWork.kt:159)
+	at org.jetbrains.kotlin.compilerRunner.GradleKotlinCompilerWork.run(GradleKotlinCompilerWork.kt:111)
+	at org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction.execute(GradleCompilerRunnerWithWorkers.kt:76)
+	at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:66)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1$1.create(NoIsolationWorkerFactory.java:62)
+	at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.lambda$execute$0(NoIsolationWorkerFactory.java:62)
+	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
+	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:210)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:205)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:54)
+	at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
+	at org.gradle.workers.internal.NoIsolationWorkerFactory$1.execute(NoIsolationWorkerFactory.java:59)
+	at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$0(DefaultWorkerExecutor.java:174)
+	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:194)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.access$700(DefaultConditionalExecutionQueue.java:127)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner$1.run(DefaultConditionalExecutionQueue.java:169)
+	at org.gradle.internal.Factories$1.create(Factories.java:31)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
+	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:132)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:164)
+	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:133)
+	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
+	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
+	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
+	at java.base/java.lang.Thread.run(Unknown Source)
+
+

--- a/app/src/main/java/com/example/hwaroak/message/SSEClient.kt
+++ b/app/src/main/java/com/example/hwaroak/message/SSEClient.kt
@@ -70,7 +70,7 @@ class SSEClient(private val context: Context) {
                         // createdAt → "2025-07-29T20:35:51.652606127" → "20:35" 추출
                         val time = alarmEvent.createdAt.substringAfter("T").substring(0, 5)
 
-                        val title = "${alarmEvent.title} (${time})"
+                        val title = alarmEvent.title
                         val message = alarmEvent.message
 
                         showNotification(title, message)

--- a/app/src/main/java/com/example/hwaroak/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/calendar/CalendarFragment.kt
@@ -139,6 +139,9 @@ class CalendarFragment : Fragment() {
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()
 
+        /**얘는 상단다 없음 < X**/
+        (activity as? MainActivity)?.setTopBar(isBackVisible = true)
+
         //초기화
         todayDec    = TodayDecorator(requireContext())
         selectedDec = SelectedDecorator(requireContext())

--- a/app/src/main/java/com/example/hwaroak/ui/diary/DiaryFinishFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/diary/DiaryFinishFragment.kt
@@ -90,6 +90,9 @@ class DiaryFinishFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         diaryPref = requireContext().getSharedPreferences("diary", MODE_PRIVATE)
 
+        /**얘는 바 없음**/
+        (activity as? MainActivity)?.setTopBar(isBackVisible = false)
+
         //애니메이션
         binding.diaryFinishResultImv.visibility = TextView.INVISIBLE
         binding.diaryFinishFire1Imv.visibility= TextView.INVISIBLE

--- a/app/src/main/java/com/example/hwaroak/ui/diary/DiaryWriteFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/diary/DiaryWriteFragment.kt
@@ -32,6 +32,7 @@ import com.example.hwaroak.api.login.repository.LoginRepository
 import com.example.hwaroak.data.DiaryContent
 import com.example.hwaroak.data.DiaryEmotion
 import com.example.hwaroak.databinding.FragmentDiaryWriteBinding
+import com.example.hwaroak.ui.main.MainActivity
 import org.json.JSONObject
 import org.threeten.bp.format.DateTimeFormatter
 import java.text.SimpleDateFormat
@@ -123,6 +124,9 @@ class DiaryWriteFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()
+
+        /**상단 바 표시 < **/
+        (activity as? MainActivity)?.setTopBar("오늘의 화록",isBackVisible = true)
 
         //맨 처음 날짜 표시
         updateDateText()

--- a/app/src/main/java/com/example/hwaroak/ui/friend/AddFriendFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/friend/AddFriendFragment.kt
@@ -18,6 +18,7 @@ import com.example.hwaroak.api.friend.access.FriendViewModel
 import com.example.hwaroak.api.friend.access.FriendViewModelFactory
 import com.example.hwaroak.api.friend.repository.FriendRepository
 import com.example.hwaroak.databinding.FragmentAddFriendBinding
+import com.example.hwaroak.ui.main.MainActivity
 
 class AddFriendFragment : Fragment() {
 
@@ -39,6 +40,9 @@ class AddFriendFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        /**친구 검색 상단 바**/
+        (activity as? MainActivity)?.setTopBar("친구 검색",isBackVisible = true)
 
         val repository = FriendRepository(HwaRoakClient.friendService)
         val factory = FriendViewModelFactory(repository)

--- a/app/src/main/java/com/example/hwaroak/ui/friend/FriendListFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/friend/FriendListFragment.kt
@@ -18,6 +18,7 @@ import com.example.hwaroak.api.friend.access.FriendViewModel
 import com.example.hwaroak.api.friend.access.FriendViewModelFactory
 import com.example.hwaroak.api.friend.repository.FriendRepository
 import com.example.hwaroak.databinding.FragmentFriendListBinding
+import com.example.hwaroak.ui.main.MainActivity
 
 //처음 화면
 class FriendListFragment : Fragment() {
@@ -42,6 +43,9 @@ class FriendListFragment : Fragment() {
     // 뷰 생성 후 로직 처리
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        /**상단 바**/
+        (activity as? MainActivity)?.setTopBar("친구 목록",isBackVisible = true)
 
         //viewmodel
         val prefs = requireContext().getSharedPreferences("user", Context.MODE_PRIVATE)

--- a/app/src/main/java/com/example/hwaroak/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/HomeFragment.kt
@@ -51,6 +51,9 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        /**일단 홈 화면에서는 < 없애기**/
+        (activity as? MainActivity)?.setTopBar(isBackVisible = false)
+
         // ItemService 인스턴스를 NetworkModule에서 가져옵니다.
         val itemService = HwaRoakClient.itemApiService // NetworkModule.kt에 정의된 itemApiService 사용
 

--- a/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
@@ -53,9 +53,9 @@ class MainActivity : AppCompatActivity() {
 
 
 
-        //테스트
+        //SSE 연결테스트
         val sseClient = SSEClient(this)
-        //sseClient.connectToSSE()
+        sseClient.connectToSSE()
 
 
 

--- a/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.hwaroak.ui.main
 
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
@@ -28,23 +29,35 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
 
+    private lateinit var pref: SharedPreferences
+    private lateinit var title: String
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        enableEdgeToEdge()
+        setContentView(binding.root)
 
         //ThreeTenABP 초기화(애플리케이션 상 1번)
         com.jakewharton.threetenabp.AndroidThreeTen.init(applicationContext)
 
         //splash 화면 테마 되돌리기
         setTheme(R.style.Theme_HwaRoak)
+        pref = getSharedPreferences("user", MODE_PRIVATE)
+        val name = pref.getString("nickname", "") ?: ""
+        val nickname = pref.getString("cachedNickname", "") ?: ""
+
+        title = if(nickname == "") "${name}의 화록" else "${nickname}의 화록"
+        binding.mainTitleTv.text = title
+
+
 
         //테스트
         val sseClient = SSEClient(this)
         //sseClient.connectToSSE()
 
-        binding = ActivityMainBinding.inflate(layoutInflater)
-        enableEdgeToEdge()
-        setContentView(binding.root)
+
 
         //키해시값 추출(자유롭게 삭제가능)
         val keyHash = Utility.getKeyHash(this)
@@ -129,6 +142,26 @@ class MainActivity : AppCompatActivity() {
             // BottomNavigationView는 보이게 설정
             binding.mainBnv.visibility = View.VISIBLE
         }
+        //뒤로 가기 < 버튼
+        binding.mainBackBtn.setOnClickListener {
+            // 현재 화면 확인
+            val current = supportFragmentManager
+                .findFragmentById(R.id.main_fragmentContainer)
+
+            // 1. 백스택에 프래그먼트가 존재하면 pop (예: MyPage → EditProfile → 뒤로 → MyPage)
+            if (supportFragmentManager.backStackEntryCount > 0) {
+                supportFragmentManager.popBackStack()
+                
+            }
+            // 2. 홈 화면으로 돌아가게 하기
+            else if (current !is HomeFragment) {
+                // 홈으로 돌아가기
+                binding.mainBnv.selectedItemId = R.id.homeFragment
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.main_fragmentContainer, HomeFragment())
+                    .commit()
+            } 
+        }
 
 
         //뒤로 가기 시 일단 HomeFragment 이동 후 종료
@@ -206,5 +239,20 @@ class MainActivity : AppCompatActivity() {
         binding.mainLockerBtn.visibility = View.VISIBLE
         binding.mainTitleTv.visibility = View.VISIBLE
     }
+
+    //다른 fragment에서 동적 제어
+    fun setTopBar(mytitle: String, isBackVisible: Boolean){
+        binding.mainTitleTv.text = mytitle
+        binding.mainBackBtn.visibility = if (isBackVisible) View.VISIBLE else View.INVISIBLE
+
+    }
+    fun setTopBar(isBackVisible: Boolean){
+        binding.mainTitleTv.text = title
+        binding.mainBackBtn.visibility = if (isBackVisible) View.VISIBLE else View.INVISIBLE
+    }
+    fun changeTitle(newTitle: String){
+        title = "${newTitle}의 화록"
+    }
+
 
 }

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/AnnouncementFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/AnnouncementFragment.kt
@@ -21,6 +21,7 @@ import com.example.hwaroak.api.notice.access.NoticeViewModelFactory
 import com.example.hwaroak.api.notice.repository.NoticeRepository
 import com.example.hwaroak.data.AnnouncementData
 import com.example.hwaroak.databinding.FragmentAnnouncementBinding
+import com.example.hwaroak.ui.main.MainActivity
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -63,6 +64,7 @@ class AnnouncementFragment : Fragment() {
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()
 
+        (activity as? MainActivity)?.setTopBar("공지사항", isBackVisible = true)
 
         /**공지 observer**/
         noticeViewModel.noticeList.observe(viewLifecycleOwner) { result ->

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
@@ -27,6 +27,7 @@ import com.example.hwaroak.api.mypage.repository.MemberRepository
 import com.example.hwaroak.data.MypageData
 import com.example.hwaroak.databinding.DialogChangeNicknameBinding
 import com.example.hwaroak.databinding.FragmentEditProfileBinding
+import com.example.hwaroak.ui.main.MainActivity
 
 class EditProfileFragment : Fragment() {
 
@@ -52,6 +53,9 @@ class EditProfileFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        /**상단바 수정**/
+        (activity as? MainActivity)?.setTopBar("프로필 수정", isBackVisible = true)
 
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()
@@ -89,6 +93,9 @@ class EditProfileFragment : Fragment() {
             // 수정한 닉네임 캐시에 즉시 저장
             val pref = requireContext().getSharedPreferences("user", Context.MODE_PRIVATE)
             pref.edit().putString("cachedNickname", nickname).apply()
+
+            //상단 바 이름에도 적용
+            (activity as? MainActivity)?.changeTitle(nickname)
 
             // 수정 요청 실행
             memberViewModel.editProfile(accessToken, nickname, profileImgUrl, introduction)
@@ -171,7 +178,6 @@ class EditProfileFragment : Fragment() {
 
                 // EditProfileFragment의 닉네임 TextView 업데이트
                 binding.nickname.text = newNickname
-
                 dialog.dismiss() // 다이얼로그 닫기
             }
 

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/MypageFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/MypageFragment.kt
@@ -23,6 +23,7 @@ import com.example.hwaroak.databinding.DialogLogoutCheckBinding
 import com.example.hwaroak.databinding.FragmentMypageBinding
 import com.example.hwaroak.ui.friend.AddFriendFragment
 import com.example.hwaroak.ui.login.LoginKakaoActivity
+import com.example.hwaroak.ui.main.MainActivity
 import com.github.mikephil.charting.animation.Easing
 import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
@@ -55,6 +56,9 @@ class MypageFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        /**상단바 설정**/
+        (activity as? MainActivity)?.setTopBar(isBackVisible = true)
 
         initPieChart()
         setupNavigation()

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/SettingFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/SettingFragment.kt
@@ -20,6 +20,7 @@ import com.example.hwaroak.api.notice.access.NoticeViewModelFactory
 import com.example.hwaroak.api.notice.model.AlarmSettingRequest
 import com.example.hwaroak.api.notice.repository.NoticeRepository
 import com.example.hwaroak.databinding.FragmentSettingBinding
+import com.example.hwaroak.ui.main.MainActivity
 import java.util.Calendar
 import kotlin.getValue
 
@@ -84,6 +85,8 @@ class SettingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        (activity as? MainActivity)?.setTopBar("알람 설정", isBackVisible = true)
+        
         //초기 설정
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/TermsFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/TermsFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.hwaroak.R
+import com.example.hwaroak.ui.main.MainActivity
 
 class TermsFragment : Fragment() {
 
@@ -18,6 +19,13 @@ class TermsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         return inflater.inflate(R.layout.fragment_terms, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (activity as? MainActivity)?.setTopBar("이용 약관", isBackVisible = true)
+
     }
 
 }


### PR DESCRIPTION
# [어헛차/#72] - 상단바 로직 연결 및 SSE를 이용한 푸시 알림 구현

## 1. 상단바 로직 연결
 - SharedPref의 "user" 버번에서 "cachedNickname" 값을 이용해 상단바에 **"누구누구의 화록"** 처럼 출력되도록 설정
 - 프로필 수정 화면에서 닉네임을 바꾼 경우, 바로 이를 반영해 상단바에 **"변경된이름의 화록"** 처럼 출력되도록 설정
 - 기능 명세서에 따라 특정 기능에서는 상단바 이름을 해당에 맞게 설정
 - 상단 바의 뒤로 가기 버튼 로직을 시스템 뒤로 가기 처럼 홈 화면&이전 fragment로 이동하도록 로직을 설정 

## 2. SSE 연결 및 푸시 알람 설정
 - Swagger에 정의된 것을 통해 SSE Http 연결을 구현
 - 단방향 수신으로 특정 정보가 수신될 경우, 해당 정보를 파싱해 알람 정보일 경우 이를 Notification에 전송해 알람 쏘게 하기
   -  ex. 맨 처음 연결 시 subscribe라는 handshake가 오는데 이는 무시

### 현 SSE에서의 문제점
  1. 약 1분마다 SSE 연결이 끊기는 문제가 발생 **("SSE 연결 실패 : java.io.EOFException")** 
  2. SSE 통신이 항상 연결되어 있어야 하기 때문에, 앱이 꺼져있거나 백그라운드 상태일 땐 푸시 알람이 띄워지지 않음.
    - 백그라운드일 경우 : 앱을 다시 포그라운드로 설정하면 푸시 알람이 뜸
    - 앱이 꺼진 상태 : 푸시 알람 자체가 X (앱을 켜도 X) 