### PR TITLE
[스탠다드/Back_Connect, Logic] - API 관련 구조 변경 및 리팩토링 오류 수정

### DIFF
--- a/app/src/main/java/com/example/hwaroak/api/mypage/access/MemberViewModel.kt
+++ b/app/src/main/java/com/example/hwaroak/api/mypage/access/MemberViewModel.kt
@@ -27,9 +27,9 @@ class MemberViewModel(private val repository: MemberRepository): ViewModel() {
         }
     }
 
-    fun editProfile(token: String, nickname: String, profileImgUrl: String, introduction: String) {
+    fun editProfile(token: String, nickname: String, introduction: String) {
         viewModelScope.launch {
-            val result = repository.editProfile(token, nickname, profileImgUrl, introduction)
+            val result = repository.editProfile(token, nickname, introduction)
             _editProfileResult.postValue(result)
 
             if (result.isSuccess) {

--- a/app/src/main/java/com/example/hwaroak/api/mypage/model/MemberResponse.kt
+++ b/app/src/main/java/com/example/hwaroak/api/mypage/model/MemberResponse.kt
@@ -12,7 +12,6 @@ data class MemberInfoResponse(
 // 2. 회원 정보 수정
 data class EditProfileRequest(
     val nickname: String,
-    val profileImageUrl: String,
     val introduction: String
 )
 data class EditProfileResponse(

--- a/app/src/main/java/com/example/hwaroak/api/mypage/repository/MemberRepository.kt
+++ b/app/src/main/java/com/example/hwaroak/api/mypage/repository/MemberRepository.kt
@@ -27,11 +27,10 @@ class MemberRepository(private val service: MemberService) {
     suspend fun editProfile(
         token: String,
         nickname: String,
-        profileImgUrl: String,
         introduction: String
     ): Result<EditProfileResponse> {
         return try {
-            val req = EditProfileRequest(nickname, profileImgUrl, introduction)
+            val req = EditProfileRequest(nickname, introduction)
             val response = service.editProfile("Bearer $token", req)
             val body = response.body()
 

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
@@ -1,5 +1,6 @@
 package com.example.hwaroak.ui.mypage
 
+import android.R.attr.text
 import android.app.AlertDialog
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -76,9 +77,9 @@ class EditProfileFragment : Fragment() {
                 Log.d("member", "불러오기 성공")
                 Log.d("member", "닉네임=${data.nickname}")
                 Log.d("member", "자기소개=${data.introduction}")
-                binding.nickname.setText(data.nickname)
-                binding.userId.setText(data.userId)
-                binding.etIntroduce.setText(data.introduction ?: "")
+                binding.editProfileNicknameTv.setText(data.nickname)
+                binding.editProfileUserIdTv.setText(data.userId)
+                binding.editProfileIntroductionEt.setText(data.introduction ?: "")
             }
 
             result.onFailure {
@@ -88,20 +89,20 @@ class EditProfileFragment : Fragment() {
         }
 
         // 바텀시트다이얼로그 띄우기 (로직은 밑에 있음)
-        binding.btnChangeProfileImage.setOnClickListener {
+        binding.editProfileImageBtn.setOnClickListener {
             showChangeImageDialog()
         }
 
-        binding.btnCopyId.setOnClickListener {
-            val userId = binding.userId.text.toString()
+        binding.editProfileCopyIdBtn.setOnClickListener {
+            val userId = binding.editProfileUserIdTv.text.toString()
             copyUserIdToClipboard(userId)
         }
 
         // 저장 버튼 리스너
-        binding.btnSave.setOnClickListener {
+        binding.editProfileSaveBtn.setOnClickListener {
             parentFragmentManager.popBackStack()
-            val nickname = binding.nickname.text.toString().trim()
-            val introduction = binding.etIntroduce.text.toString().trim()
+            val nickname = binding.editProfileNicknameTv.text.toString().trim()
+            val introduction = binding.editProfileIntroductionEt.text.toString().trim()
             val profileImgUrl = "" // 추후 이미지 업로드 기능과 연결 가능
 
             // 수정한 닉네임 캐시에 즉시 저장
@@ -112,7 +113,7 @@ class EditProfileFragment : Fragment() {
             (activity as? MainActivity)?.changeTitle(nickname)
 
             // 수정 요청 실행
-            memberViewModel.editProfile(accessToken, nickname, profileImgUrl, introduction)
+            memberViewModel.editProfile(accessToken, nickname, introduction)
 
             // observer 정의
             val resultObserver = object : Observer<Result<EditProfileResponse>> {
@@ -136,7 +137,7 @@ class EditProfileFragment : Fragment() {
         }
 
         // 닉네임 변경 연필 버튼 리스너
-        binding.btnEditNickname.setOnClickListener {
+        binding.editProfileNicknameBtn.setOnClickListener {
             showChangeNicknameDialog() // 다이얼로그 표시 함수 호출
         }
     }
@@ -155,7 +156,7 @@ class EditProfileFragment : Fragment() {
             val dialogBinding = DialogChangeNicknameBinding.inflate(LayoutInflater.from(requireContext()))
 
             // 2. 현재 닉네임 가져와서 EditText에 적어놓기
-            val currentNickname = binding.nickname.text.toString() // EditProfileFragment의 닉네임 가져오기
+            val currentNickname = binding.editProfileNicknameTv.text.toString() // EditProfileFragment의 닉네임 가져오기
             dialogBinding.dialogNicknameEt.setText(currentNickname)
             dialogBinding.dialogNicknameEt.setSelection(currentNickname.length) // EditText에서 커서 맨 뒤로 가게 하기
 
@@ -192,7 +193,7 @@ class EditProfileFragment : Fragment() {
                 }
 
                 // EditProfileFragment의 닉네임 TextView 업데이트
-                binding.nickname.text = newNickname
+                binding.editProfileNicknameTv.text = newNickname
                 dialog.dismiss() // 다이얼로그 닫기
             }
 

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -49,8 +49,8 @@
                 android:background="@drawable/bg_circle_button"
                 android:scaleType="center"
                 android:src="@drawable/ic_camera"
-                app:layout_constraintBottom_toBottomOf="@id/mypage_profile_image_iv"
-                app:layout_constraintEnd_toEndOf="@id/mypage_profile_image_iv"
+                app:layout_constraintBottom_toBottomOf="@id/edit_profile_image_iv"
+                app:layout_constraintEnd_toEndOf="@id/edit_profile_image_iv"
                 tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -58,7 +58,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:padding="16dp"
-                app:layout_constraintTop_toBottomOf="@id/mypage_profile_image_iv"
+                app:layout_constraintTop_toBottomOf="@id/edit_profile_image_iv"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent">
 


### PR DESCRIPTION
### 작업 내용
- 위젯 ID를 작명 컨벤션에 맞게 리팩토링하였습니다.
- 기존 회원 정보 수정 API에서 Request Body에 프로필 사진 관련 항목이 사라짐에 따라 구조 변경 완료했습니다.

### 이슈 번호
#47 #64 