### PR TITLE
[어헛차/logic] QA 작업 및 수정 완료

### DIFF
--- a/app/src/main/java/com/example/hwaroak/api/notice/model/NoticeResponse.kt
+++ b/app/src/main/java/com/example/hwaroak/api/notice/model/NoticeResponse.kt
@@ -33,6 +33,7 @@ data class NoticeRegisterRequest(
 // 로그인한 사용자의 모든 알람을 최신순으로 조회합니다. (request는 아무것도 X)
 data class AlarmListResponse(
     val id: Int,
+    val userId: String,
     val title: String,
     val content: String,
     val alarmType: String,

--- a/app/src/main/java/com/example/hwaroak/data/NoticeItem.kt
+++ b/app/src/main/java/com/example/hwaroak/data/NoticeItem.kt
@@ -2,6 +2,7 @@ package com.example.hwaroak.data
 
 data class NoticeItem(
     val id: Int,
+    val friendId: String,
     val title: String,
     val content: String,
     val alarmType: String,

--- a/app/src/main/java/com/example/hwaroak/ui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/calendar/CalendarFragment.kt
@@ -146,7 +146,7 @@ class CalendarFragment : Fragment() {
         accessToken = pref.getString("accessToken", "").toString()
 
         /**얘는 상단다 없음 < X**/
-        (activity as? MainActivity)?.setTopBar(isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar(isBackVisible = true, false)
 
         diaryPref = requireContext().getSharedPreferences("diary", MODE_PRIVATE)
 

--- a/app/src/main/java/com/example/hwaroak/ui/diary/DiaryFinishFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/diary/DiaryFinishFragment.kt
@@ -91,7 +91,7 @@ class DiaryFinishFragment : Fragment() {
         diaryPref = requireContext().getSharedPreferences("diary", MODE_PRIVATE)
 
         /**얘는 바 없음**/
-        (activity as? MainActivity)?.setTopBar(isBackVisible = false)
+        (activity as? MainActivity)?.setTopBar(isBackVisible = false, false)
 
         //애니메이션
         binding.diaryFinishResultImv.visibility = TextView.INVISIBLE

--- a/app/src/main/java/com/example/hwaroak/ui/diary/DiaryWriteFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/diary/DiaryWriteFragment.kt
@@ -126,7 +126,7 @@ class DiaryWriteFragment : Fragment() {
         accessToken = pref.getString("accessToken", "").toString()
 
         /**상단 바 표시 < **/
-        (activity as? MainActivity)?.setTopBar("오늘의 화록",isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("오늘의 화록",isBackVisible = true, false)
 
         //맨 처음 날짜 표시
         updateDateText()

--- a/app/src/main/java/com/example/hwaroak/ui/friend/AddFriendFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/friend/AddFriendFragment.kt
@@ -42,7 +42,7 @@ class AddFriendFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         /**친구 검색 상단 바**/
-        (activity as? MainActivity)?.setTopBar("친구 검색",isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("친구 검색",isBackVisible = true, false)
 
         val repository = FriendRepository(HwaRoakClient.friendService)
         val factory = FriendViewModelFactory(repository)
@@ -126,6 +126,11 @@ class AddFriendFragment : Fragment() {
             }
         }
 
+    }
+
+    override fun onResume() {
+        super.onResume()
+        (activity as? MainActivity)?.setTopBar("친구 검색",isBackVisible = true, false)
     }
 
     //query가 비어있으면 기본 안내만 표시, 결과 없으면 없음 표시, 결과 있으면 recycler 표시

--- a/app/src/main/java/com/example/hwaroak/ui/friend/FriendFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/friend/FriendFragment.kt
@@ -16,6 +16,15 @@ class FriendFragment : Fragment() {
 
     private var currentChild: FriendListFragment? = null
 
+    private var isLoadFromAlarm = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            isLoadFromAlarm = it.getBoolean(ARG_SHOW_REQUESTS, false)
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
@@ -32,6 +41,11 @@ class FriendFragment : Fragment() {
         //처음 진입 시 친구 목록 프래그먼트 표시
         if (savedInstanceState == null) {
             showFriendListFragment()
+        }
+
+        if(isLoadFromAlarm){
+            showRequestFragment()
+            updateTabStyle(isFriendList = false)
         }
 
         // 친구 목록 탭 클릭
@@ -121,4 +135,18 @@ class FriendFragment : Fragment() {
         super.onDestroyView()
         _binding = null
     }
+
+
+    /**화면 이동 관련!! -> 바로 친구 요청 페이지로 이동하기 위함입니다!**/
+    companion object {
+        private const val ARG_SHOW_REQUESTS = "show_requests"
+        fun newInstance(showRequests: Boolean): FriendFragment {
+            val fragment = FriendFragment()
+            val args = Bundle()
+            args.putBoolean(ARG_SHOW_REQUESTS, showRequests)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/hwaroak/ui/friend/FriendListFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/friend/FriendListFragment.kt
@@ -45,7 +45,7 @@ class FriendListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         /**상단 바**/
-        (activity as? MainActivity)?.setTopBar("친구 목록",isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("친구 목록",isBackVisible = true, false)
 
         //viewmodel
         val prefs = requireContext().getSharedPreferences("user", Context.MODE_PRIVATE)
@@ -195,6 +195,11 @@ class FriendListFragment : Fragment() {
 
         pendingDeleteList.clear()
         toggleManageMode()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        (activity as? MainActivity)?.setTopBar("친구 목록",isBackVisible = true, false)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/hwaroak/ui/friend/FriendVisitFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/friend/FriendVisitFragment.kt
@@ -19,6 +19,7 @@ import com.example.hwaroak.api.friend.access.FriendViewModel
 import com.example.hwaroak.api.friend.access.FriendViewModelFactory
 import com.example.hwaroak.api.friend.repository.FriendRepository
 import com.example.hwaroak.databinding.FragmentFriendVisitBinding
+import com.example.hwaroak.ui.main.MainActivity
 
 class FriendVisitFragment : Fragment() {
 
@@ -47,6 +48,9 @@ class FriendVisitFragment : Fragment() {
             FriendViewModelFactory(FriendRepository(friendService))
         )[FriendViewModel::class.java]
 
+        //초기 방어
+        (activity as? MainActivity)?.setTopBar("불러오는 중...",isBackVisible = true, true)
+
         //UI 초기화 받아오는데 오래 걸릴 경우 표시
         binding.tvFriendTitle.text = "불러오는 중..."
         binding.friendVisitBubbleTv.text = "불러오는 중..."
@@ -59,6 +63,7 @@ class FriendVisitFragment : Fragment() {
             // 저장해놓기
             originalStatusMessage = data.message
 
+            (activity as? MainActivity)?.setTopBar("${data.nickname}의 화록",isBackVisible = true, true)
 
             // UI 갱신
             binding.tvFriendTitle.text = "${data.nickname}의 화록"

--- a/app/src/main/java/com/example/hwaroak/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/HomeFragment.kt
@@ -60,7 +60,7 @@ class HomeFragment : Fragment() {
         diaryPref = requireContext().getSharedPreferences("diary", MODE_PRIVATE)
 
         /**일단 홈 화면에서는 < 없애기**/
-        (activity as? MainActivity)?.setTopBar(isBackVisible = false)
+        (activity as? MainActivity)?.setTopBar(isBackVisible = false, true)
 
         // ItemService 인스턴스를 NetworkModule에서 가져옵니다.
         val itemService = HwaRoakClient.itemApiService // NetworkModule.kt에 정의된 itemApiService 사용

--- a/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
@@ -181,6 +181,19 @@ class MainActivity : AppCompatActivity() {
         binding.mainBnv.selectedItemId = menuItemId
     }
 
+    //친구 요청 페이지로 이동 (bottomNav이동 -> bundle에 인자 담아 FriendFragment 이동 -> freind에서 UI 처리)
+    fun navigateToFriendRequestPage() {
+        // BottomNavigationView의 탭을 '친구' 탭으로 선택
+        binding.mainBnv.selectedItemId = R.id.friendFragment
+
+        // FriendFragment의 newInstance를 호출하여 인수를 전달
+        val friendFragment = FriendFragment.newInstance(showRequests = true)
+
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.main_fragmentContainer, friendFragment)
+            .commit()
+    }
+
     //강제로 일기 작성 탭으로 이동하게 하기(단 bundle에 내용 채워서)
     fun navigateToDiaryWith(bundle: Bundle) {
         // 1. programmatically select the Diary tab
@@ -241,17 +254,30 @@ class MainActivity : AppCompatActivity() {
     }
 
     //다른 fragment에서 동적 제어
-    fun setTopBar(mytitle: String, isBackVisible: Boolean){
+    fun setTopBar(mytitle: String, isBackVisible: Boolean, isShow: Boolean){
         binding.mainTitleTv.text = mytitle
         binding.mainBackBtn.visibility = if (isBackVisible) View.VISIBLE else View.INVISIBLE
+        if(isShow){
+            binding.mainLockerBtn.visibility = View.VISIBLE
+        }
+        else{
+            binding.mainLockerBtn.visibility = View.INVISIBLE
+        }
 
     }
-    fun setTopBar(isBackVisible: Boolean){
+    fun setTopBar(isBackVisible: Boolean, isShow: Boolean){
         binding.mainTitleTv.text = title
         binding.mainBackBtn.visibility = if (isBackVisible) View.VISIBLE else View.INVISIBLE
+        if(isShow){
+            binding.mainLockerBtn.visibility = View.VISIBLE
+        }
+        else{
+            binding.mainLockerBtn.visibility = View.INVISIBLE
+        }
     }
     fun changeTitle(newTitle: String){
         title = "${newTitle}의 화록"
+
     }
 
 

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/AnnouncementFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/AnnouncementFragment.kt
@@ -64,7 +64,7 @@ class AnnouncementFragment : Fragment() {
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()
 
-        (activity as? MainActivity)?.setTopBar("공지사항", isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("공지사항", isBackVisible = true, false)
 
         /**공지 observer**/
         noticeViewModel.noticeList.observe(viewLifecycleOwner) { result ->

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
@@ -65,7 +65,7 @@ class EditProfileFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         /**상단바 수정**/
-        (activity as? MainActivity)?.setTopBar("프로필 수정", isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("프로필 수정", isBackVisible = true, false)
 
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/MypageFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/MypageFragment.kt
@@ -60,7 +60,7 @@ class MypageFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         /**상단바 설정**/
-        (activity as? MainActivity)?.setTopBar(isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar(isBackVisible = true, false)
 
         initPieChart()
         setupNavigation()

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/SettingFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/SettingFragment.kt
@@ -85,7 +85,7 @@ class SettingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        (activity as? MainActivity)?.setTopBar("알람 설정", isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("알람 설정", isBackVisible = true, false)
         
         //초기 설정
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/TermsFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/TermsFragment.kt
@@ -24,7 +24,7 @@ class TermsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        (activity as? MainActivity)?.setTopBar("이용 약관", isBackVisible = true)
+        (activity as? MainActivity)?.setTopBar("이용 약관", isBackVisible = true, false)
 
     }
 

--- a/app/src/main/java/com/example/hwaroak/ui/notification/NoticeFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/notification/NoticeFragment.kt
@@ -1,5 +1,6 @@
 package com.example.hwaroak.ui.notification
 
+import android.R.attr.fragment
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
 import android.os.Bundle
@@ -64,8 +65,10 @@ class NoticeFragment : Fragment() {
         /**알람함 observe**/
         noticeViewModel.alarmList.observe(viewLifecycleOwner) { result ->
             result.onSuccess { resp ->
+                /**알람 정보 및 친구의 ID를 따로 빼기**/
+
                 val noticeList = resp.map { item ->
-                    NoticeItem(item.id, item.title, item.content,
+                    NoticeItem(item.id, item.userId,item.title, item.content,
                         item.alarmType, item.isRead, item.createdAt)
                 }
 
@@ -77,6 +80,8 @@ class NoticeFragment : Fragment() {
                     //불 키우기
                     if(selectedNotice.alarmType == "FIRE"){
                         (activity as? MainActivity)?.selectTab(R.id.friendFragment)
+
+
                     }
                     //월간 리포트
                     else if(selectedNotice.alarmType == "DAILY"){
@@ -100,7 +105,8 @@ class NoticeFragment : Fragment() {
                     }
                     //친구 요청
                     else if(selectedNotice.alarmType == "FRIEND_REQUEST"){
-                        (activity as? MainActivity)?.selectTab(R.id.friendFragment)
+                        (activity as? MainActivity)?.navigateToFriendRequestPage()
+
                     }
 
                 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,11 +9,11 @@
     tools:context=".ui.main.MainActivity">
 
     <!--상단 바-->
-
+d
     <ImageButton
         android:id="@+id/main_back_btn"
-        android:layout_width="12dp"
-        android:layout_height="24dp"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
         android:src="@drawable/ic_arrow_back"
         android:background="@color/transparent"
         android:layout_marginTop="25dp"

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -8,8 +8,8 @@
 
     <ImageButton
         android:id="@+id/notice_back_btn"
-        android:layout_width="12dp"
-        android:layout_height="24dp"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
         android:src="@drawable/ic_arrow_back"
         android:background="@color/transparent"
         android:layout_marginTop="25dp"


### PR DESCRIPTION
# [어헛차/logic] QA 작업 및 수정 완료

## 1. 상단 바 뒤로 가기 버튼 크기 조정
 - 기본 뒤로 가기 버튼의 크기를 (12*24)dp -> (32*32)dp 으로 키움

## 2. 상단 바 보관함 버튼 보이는 로직 수정
 - 기존에 모든 화면에 대해 아이템 보관함이 보이는 것을 수정
 - 메인 화면 & 친구 방문 페이지인 경우에만 아이템 보관함 버튼이 보이고, 나머지는 숨김 처리
   - 각 화면에서 상단바 이름을 수정하는 로직을 개선하여 적용 ( **대부분의 kt 파일에 대한 수정이 발생** )

## 3. 알림함에서 친구 요청 알람 터치 시 이동 로직 수정
  - 기존에는 친구 리스트 화면으로만 이동 (bottomNav에서 id 변경만 진행)
  - friendFragment로 이동 후 -> friendFragment에서 추가로 이동하는 로직 추가
    1. companion object를 이용하여, 알람 -> 친구 요청 페이지로 이동 시 FriendFragment 생성 및 bundle에 boolean 값을 전달
    2. 해당 bundle 값을 비교해 이동하는 로직을 추가 