### PR TITLE
[어헛차/#90] - QA 수정 완료(알람 상단바 UI/로직 개선, 알람페이지 이동 시 bottomNav문제)

### DIFF
--- a/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/main/MainActivity.kt
@@ -143,7 +143,7 @@ class MainActivity : AppCompatActivity() {
                 .addToBackStack(null)
                 .commit()
             // NoticeFragment로 갈 때 상단 바 숨김(모양이 다르므로 fragment에서 교체)
-            hideMainTopBar()// 상단 바 숨김
+            //hideMainTopBar()// 상단 바 숨김
             // BottomNavigationView는 보이게 설정
             binding.mainBnv.visibility = View.VISIBLE
         }
@@ -233,12 +233,14 @@ class MainActivity : AppCompatActivity() {
 
                 // 1. 백스택에 프래그먼트가 존재하면 pop (예: MyPage → EditProfile → 뒤로 → MyPage)
                 if (supportFragmentManager.backStackEntryCount > 0) {
+                    Log.d("log_back", "여기서 뒤로 가요!1")
                     supportFragmentManager.popBackStack()
                     return
                 }
 
                 if (current !is HomeFragment) {
                     // 홈으로 돌아가기
+                    Log.d("log_back", "여기서 뒤로 가요!2")
                     binding.mainBnv.selectedItemId = R.id.homeFragment
                     supportFragmentManager.beginTransaction()
                         .replace(R.id.main_fragmentContainer, HomeFragment())
@@ -267,6 +269,7 @@ class MainActivity : AppCompatActivity() {
         binding.mainLockerBtn.visibility = View.VISIBLE
         binding.mainTitleTv.visibility = View.VISIBLE
     }
+    
 
     //다른 fragment에서 동적 제어
     fun setTopBar(mytitle: String, isBackVisible: Boolean, isShow: Boolean){
@@ -290,6 +293,19 @@ class MainActivity : AppCompatActivity() {
             binding.mainLockerBtn.visibility = View.INVISIBLE
         }
     }
+
+    //알람 화면을 보여줄 때 세팅
+    fun setTopBarNotice(){
+        binding.mainTitleTv.text = "알림"
+        binding.mainBackBtn.visibility = View.VISIBLE
+        binding.mainBellBtn.visibility = View.VISIBLE
+        binding.mainLockerBtn.visibility = View.INVISIBLE
+        binding.mainBellBtn.isEnabled = false
+    }
+    fun resetTopBarNotice(){
+        binding.mainBellBtn.isEnabled = true
+    }
+
     fun changeTitle(newTitle: String){
         title = "${newTitle}의 화록"
 

--- a/app/src/main/java/com/example/hwaroak/ui/mypage/AnalysisFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/AnalysisFragment.kt
@@ -1,5 +1,7 @@
 package com.example.hwaroak.ui.mypage
 
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -11,6 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import com.example.hwaroak.R
 import com.example.hwaroak.data.MonthViewModel
 import com.example.hwaroak.databinding.FragmentAnalysisBinding
+import com.example.hwaroak.ui.main.MainActivity
 import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
@@ -123,5 +126,17 @@ class AnalysisFragment : Fragment() {
 
             animate()
         }
+    }
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        var pref2: SharedPreferences = requireActivity().getSharedPreferences("user", MODE_PRIVATE)
+        val name = pref2.getString("nickname", "") ?: ""
+        val nickname = pref2.getString("cachedNickname", "") ?: ""
+
+        var title = if(nickname == "") "${name}의 화록" else "${nickname}의 화록"
+
+        (activity as? MainActivity)?.setTopBar(title, isBackVisible = true, false)
     }
 }

--- a/app/src/main/java/com/example/hwaroak/ui/notification/NoticeFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/notification/NoticeFragment.kt
@@ -3,6 +3,7 @@ package com.example.hwaroak.ui.notification
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -35,6 +36,8 @@ class NoticeFragment : Fragment() {
     private lateinit var pref: SharedPreferences
     private lateinit var accessToken: String
 
+    private var isGoSetting = false
+
     //viewModel 및 repository 정의
     //viewModel 정의
     // 1) Retrofit 서비스로 Repository 인스턴스 생성
@@ -57,6 +60,7 @@ class NoticeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        (activity as? MainActivity)?.setTopBarNotice()
         //초기 설정
         pref = requireContext().getSharedPreferences("user", MODE_PRIVATE)
         accessToken = pref.getString("accessToken", "").toString()
@@ -78,6 +82,7 @@ class NoticeFragment : Fragment() {
                     selectedNotice ->
                     //불 키우기
                     if (selectedNotice.alarmType == "FIRE") {
+                        parentFragmentManager.popBackStack()
                         val friendId = selectedNotice.userId  // FIRE 알림 보낸 사람 userId
                         if (!friendId.isNullOrBlank()) {
                             (activity as? MainActivity)?.navigateToFriendVisit(friendId)
@@ -88,6 +93,7 @@ class NoticeFragment : Fragment() {
                     }
                     //월간 리포트
                     else if(selectedNotice.alarmType == "DAILY"){
+                        parentFragmentManager.popBackStack()
                         (activity as? MainActivity)?.selectTab(R.id.mypageFragment)
                         requireActivity().supportFragmentManager.beginTransaction()
                             .replace(R.id.main_fragmentContainer, AnalysisFragment())
@@ -96,10 +102,12 @@ class NoticeFragment : Fragment() {
                     }
                     //일기 리마인더
                     else if(selectedNotice.alarmType == "REMINDER"){
+                        parentFragmentManager.popBackStack()
                         (activity as? MainActivity)?.selectTab(R.id.diaryFragment)
                     }
                     //공지 사항
                     else if(selectedNotice.alarmType == "NOTIFICATION"){
+                        parentFragmentManager.popBackStack()
                         (activity as? MainActivity)?.selectTab(R.id.mypageFragment)
                         requireActivity().supportFragmentManager.beginTransaction()
                             .replace(R.id.main_fragmentContainer, AnnouncementFragment())
@@ -108,6 +116,7 @@ class NoticeFragment : Fragment() {
                     }
                     //친구 요청
                     else if(selectedNotice.alarmType == "FRIEND_REQUEST"){
+                        parentFragmentManager.popBackStack()
                         (activity as? MainActivity)?.navigateToFriendRequestPage()
                     }
 
@@ -127,6 +136,7 @@ class NoticeFragment : Fragment() {
         //호출
         noticeViewModel.getAlarmList(accessToken)
 
+        /*
         binding.noticeBackBtn.setOnClickListener {
             // 뒤로가기 버튼 클릭 시 MainActivity의 상단 바를 다시 보이게 함
             (activity as? MainActivity)?.showMainTopBar()
@@ -135,11 +145,14 @@ class NoticeFragment : Fragment() {
             /**뒤로 가기를 누르면 HomeFragment로 이동 -> 해당 fragment 쪽으로 **/
             //(activity as? MainActivity)?.selectTab(R.id.homeFragment)
         }
+        */
+
         // 추후 필요시 여기에 다른 로직 구현
 
         //1. 알림 설정 누를 시 해당 화면으로 이동
         binding.btnNoticeSetting.setOnClickListener {
             // 알림 설정 화면으로 이동
+            isGoSetting = true
             parentFragmentManager.beginTransaction()
                 .replace(R.id.main_fragmentContainer, SettingFragment())
                 .addToBackStack(null)
@@ -149,13 +162,19 @@ class NoticeFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        (activity as? MainActivity)?.hideMainTopBar()
+        //(activity as? MainActivity)?.hideMainTopBar()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         // 프래그먼트 뷰가 파괴될 때 MainActivity의 상단 바를 다시 보이게 함(프래그먼트가 완전히 제거될 때 호출)
-        (activity as? MainActivity)?.showMainTopBar()
+        //if(isGoSetting){
+        //    (activity as? MainActivity)?.showMainTopBarForSetting()
+        //}
+        //else {
+        //    (activity as? MainActivity)?.showMainTopBar()
+        //}
+        (activity as? MainActivity)?.resetTopBarNotice()
         _binding = null
     }
 }

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -6,81 +6,7 @@
     android:background="@color/colorBackground">
     <!--상단바-->
 
-    <ImageButton
-        android:id="@+id/notice_back_btn"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
-        android:src="@drawable/ic_arrow_back"
-        android:background="@color/transparent"
-        android:layout_marginTop="25dp"
-        android:layout_marginStart="25dp"
-        android:visibility="visible"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
 
-    <ImageButton
-        android:id="@+id/notice_bell_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
-        android:src="@drawable/ic_bell"
-        android:background="@color/transparent"
-        android:layout_marginEnd="25dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/notice_back_btn"
-        app:layout_constraintBottom_toBottomOf="@id/notice_back_btn"/>
-
-    <TextView
-        android:id="@+id/notice_title_tv"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="알림"
-        android:layout_marginStart="10dp"
-        style="@style/freesentation6_20sp_title"
-        app:layout_constraintStart_toEndOf="@id/notice_back_btn"
-        app:layout_constraintTop_toTopOf="@id/notice_back_btn"
-        app:layout_constraintBottom_toBottomOf="@id/notice_back_btn"/>
-
-    <!--
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:background="@color/white"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-    <ImageButton
-        android:id="@+id/notice_back_btn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="25dp"
-        android:background="@android:color/transparent"
-        android:src="@drawable/ic_arrow_back"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
-
-    <TextView
-        android:id="@+id/notice_title_tv"
-        style="@style/freesentation5_20sp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="10dp"
-        android:text="알림"
-        app:layout_constraintBottom_toBottomOf="@id/notice_back_btn"
-        app:layout_constraintStart_toEndOf="@id/notice_back_btn"
-        app:layout_constraintTop_toTopOf="@id/notice_back_btn" />
-
-    <ImageButton
-        android:id="@+id/notice_bell_btn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="25dp"
-        android:layout_marginEnd="25dp"
-        android:background="@android:color/transparent"
-        android:src="@drawable/ic_bell"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    -->
 
     <!--컨텐츠박스-->
     <!--버튼-->
@@ -90,10 +16,9 @@
         android:layout_height="wrap_content"
         android:backgroundTint="@color/colorBackground"
         android:src="@drawable/btn_notice_mynotification"
-        android:layout_marginStart="10dp"
-        android:layout_marginTop="30dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/notice_back_btn"/>
+        android:layout_marginTop="20dp"
+        app:layout_constraintStart_toStartOf="@id/rv_notice_container"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <ImageButton
         android:id="@+id/btn_notice_setting"
@@ -102,7 +27,7 @@
         android:layout_marginBottom="12dp"
         android:src="@drawable/btn_notice_notification_setting"
         android:backgroundTint="@color/colorBackground"
-        android:layout_marginEnd="10dp"
+        android:layout_marginEnd="25dp"
         android:layout_marginTop="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/btn_my_notice"


### PR DESCRIPTION
# [어헛차/#90] - QA 수정 완료(알람 상단바 UI/로직 개선, 알람페이지 이동 시 bottomNav문제)

## 1. NoticeFragment UI 및 로직 다시 작성
 - 현재 NoticeFragment 진입 시, 기존 TopBar를 hide, visible 하는 구조 때문에, 각 뷰마다의 통일성 및 화면 띄우기 오류가 발생함
 - 처음에는 기존 디자인을 해치지 않는 선에 오류 수정을 진행했지만, Fragment 구조가 늘어남에 따라 모든 케이스에 대한 override 함수를 설정해야 함 ( **유지 보수 메우 떨어짐!!**  )
 - 이에 기존 UI의 상단바를 제거하고 기존 상단바를 이어 받도록 UI 재디자인 및 로직 재연결
   - MainActivity에서 제어 (이름 및 알람 아이콘 터치 비활성화)
   - NoticeFragment에서 hide/show TopBar 로직 제거 및 BackStack 관리로 제어 이관
 - 그 결과 통일성 확보 및 UI 재설정 과정에서의 오류 제거 확인

## 2. NoticeFragment에서 친구/공지 페이지 등으로 이동 시 BottomNav 갱신X 문제 개선
 - 로그 확인 결과, noticeFragment에 대한 backstack이 잔존해 있어 뒤로 가기 중 로직이 꼬인 것을 확인
 - 새 화면으로 이동할 때, PopBackStack을 이용하여 관리
 - 그 결과 정상적 이동 확인  