### PR TITLE
[스탠다드/Logic] - 프로필 사진 다이얼로그 로직 일부 수정

### DIFF
--- a/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
+++ b/app/src/main/java/com/example/hwaroak/ui/mypage/EditProfileFragment.kt
@@ -318,6 +318,7 @@ class EditProfileFragment : Fragment() {
             isDefaultImageSelected = true
 //            memberViewModel.deleteProfileImage(token)
             binding.editProfileImageIv.setImageResource(R.drawable.default_profile_image)
+            memberViewModel.clearStagedImage()
             dialog.dismiss()
         }
 
@@ -382,6 +383,9 @@ class EditProfileFragment : Fragment() {
         return token
     }
     private fun isDefaultProfileImage(): Boolean {
+        if (memberViewModel.previewUri.value != null) {
+            return false
+        }
         val url = memberViewModel.memberInfoResult.value
             ?.getOrNull()
             ?.profileImgUrl


### PR DESCRIPTION
### 작업 내용
1. 변경할 사진을 선택한 상태에서 저장하기를 누르지 않고 다시 카메라 버튼 누르면 기본 이미지 적용이 뜨지 않는다.
2. 기본 이미지 적용을 누른 상태에서 저장하기를 누르지 않고 다시 카메라 버튼 누르면 기본 이미지 적용이 여전히 뜬다.
기존 코드에 있던 위와 같은 2가지 문제를 해결하였습니다.
